### PR TITLE
V malob/impove tests

### DIFF
--- a/azure-pipelines/azure-pipelines.yml
+++ b/azure-pipelines/azure-pipelines.yml
@@ -13,6 +13,7 @@ stages:
   - template: /azure-pipelines/build_job.yml
 
 - stage: Test_Python_MacOS
+  condition: succeeded()
   dependsOn: Build_Python_MacOS
   variables:
     VmImage: 'macOS-10.14'
@@ -31,6 +32,7 @@ stages:
   - template: /azure-pipelines/build_job.yml
 
 - stage: Test_Python_Ubuntu_1604
+  condition: succeeded()
   dependsOn: Build_Python_Ubuntu_1604
   variables:
     VmImage: 'ubuntu-16.04'
@@ -49,6 +51,7 @@ stages:
   - template: /azure-pipelines/build_job.yml
 
 - stage: Test_Python_Ubuntu_1804
+  condition: succeeded()
   dependsOn: Build_Python_Ubuntu_1804
   variables:
     VmImage: 'ubuntu-18.04'
@@ -67,6 +70,7 @@ stages:
   - template: /azure-pipelines/build_job.yml
 
 - stage: Test_Python_x64_Windows
+  condition: succeeded()
   dependsOn: Build_Python_X64_Windows
   variables:
     VmImage: 'vs2017-win2016'
@@ -85,6 +89,7 @@ stages:
   - template: /azure-pipelines/build_job.yml
 
 - stage: Test_Python_x86_Windows
+  condition: succeeded()
   dependsOn: Build_Python_x86_Windows
   variables:
     VmImage: 'vs2017-win2016'
@@ -94,6 +99,7 @@ stages:
   - template: /azure-pipelines/test_job.yml
 
 - stage: Publish_GitHub_Release
+  condition: succeeded()
   dependsOn:
   - Test_Python_MacOS
   - Test_Python_Ubuntu_1604

--- a/builders/NixPythonBuilder.psm1
+++ b/builders/NixPythonBuilder.psm1
@@ -103,8 +103,8 @@ class NixPythonBuilder : PythonBuilder {
         Write-Debug "make Python $($this.Version)-$($this.Architecture) $($this.Platform)-$($this.PlatformVersion)"
         $buildOutputLocation = New-Item -Path $this.ArtifactLocation -Name "build_output.txt" -ItemType File
 
-        Execute-Command -command "make 2>&1 | tee $buildOutputLocation" -ErrorAction Continue
-        Execute-Command -command "make install" -ErrorAction Continue
+        Execute-Command -Command "make 2>&1 | tee $buildOutputLocation" -ErrorAction Continue
+        Execute-Command -Command "make install" -ErrorAction Continue
         
         Write-Debug "Done; Make log location: $buildOutputLocation"
 

--- a/builders/WinPythonBuilder.psm1
+++ b/builders/WinPythonBuilder.psm1
@@ -64,7 +64,7 @@ class WinPythonBuilder : PythonBuilder {
     }
 
     [void] Build() {
-        Write-Host "Download Python $($this.Version)[$($this.Architecture)] executable..."
+        Write-Host "Download Python $($this.Version) [$($this.Architecture)] executable..."
         $this.Download()
 
         Write-Host "Create installation script..."

--- a/helpers/common-helpers.psm1
+++ b/helpers/common-helpers.psm1
@@ -1,3 +1,21 @@
+Function Execute-Command {
+    [CmdletBinding()]
+    param(
+        [string] $Command
+    )
+
+    Write-Debug "Execute $Command"
+
+    try {
+        Invoke-Expression $Command | ForEach-Object { Write-Host $_ }
+    }
+    catch {
+        Write-Host "Error happened during command execution: $Command"
+        Write-Host "##vso[task.logissue type=error;] $_"
+    }
+}
+
+
 function New-ToolStructureDump {
     param(
         [String]$ToolPath,
@@ -12,16 +30,6 @@ function New-ToolStructureDump {
         $fileSize = $_.Length
         return "${relativePath} : ${fileSize} bytes"
     } | Out-File -FilePath $outputFile
-}
-
-function Get-CommandExitCode {
-    Param (
-      [String] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
-      $Command
-    )
-  
-    $null = Invoke-Expression -Command $Command
-    return $LASTEXITCODE
 }
 
 function IsNixPlatform {

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -34,20 +34,3 @@ Function Unpack-TarArchive {
     Write-Debug "Unpack $OutFile to $ExpandArchivePath"
     tar -C $ExpandArchivePath -$TarCommands $OutFile
 }
-
-Function Execute-Command {
-    [CmdletBinding()]
-    param(
-        [string] $Command
-    )
-
-    Write-Debug "Execute $Command"
-
-    try {
-        Invoke-Expression $Command | ForEach-Object { Write-Host $_ }
-    }
-    catch {
-        Write-Host "Error happened during command execution: $Command"
-        Write-Host "##vso[task.logissue type=error;] $_"
-    }
-}

--- a/helpers/pester-assertions.psm1
+++ b/helpers/pester-assertions.psm1
@@ -1,0 +1,27 @@
+function ShouldReturnZeroExitCode {
+    Param(
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
+        [String]$Command,
+        [switch]$Negate
+    )
+
+    $actualCommandOutput = Invoke-Expression -Command $Command
+    $actualExitCode = $LASTEXITCODE
+    Write-Host $actualCommandOutput
+
+    [bool]$succeeded = $actualExitCode -eq 0
+    if ($Negate) { $succeeded = -not $succeeded }
+
+    if (-not $succeeded)
+    {
+        $failureMessage = "Command '{$ActualValue}' has finished with exit code ${actualExitCode}"
+    }
+
+    return New-Object PSObject -Property @{
+        Succeeded      = $succeeded
+        FailureMessage = $failureMessage
+    }
+}
+
+Add-AssertionOperator -Name ReturnZeroExitCode `
+                    -Test  $function:ShouldReturnZeroExitCode

--- a/helpers/pester-assertions.psm1
+++ b/helpers/pester-assertions.psm1
@@ -1,11 +1,11 @@
 function ShouldReturnZeroExitCode {
     Param(
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
-        [String]$Command,
+        [String]$ActualValue,
         [switch]$Negate
     )
 
-    $actualCommandOutput = Invoke-Expression -Command $Command
+    $actualCommandOutput = Invoke-Expression -Command $ActualValue
     $actualExitCode = $LASTEXITCODE
     Write-Host $actualCommandOutput
 
@@ -14,7 +14,7 @@ function ShouldReturnZeroExitCode {
 
     if (-not $succeeded)
     {
-        $failureMessage = "Command '{$ActualValue}' has finished with exit code ${actualExitCode}"
+        $failureMessage = "Command '${ActualValue}' has finished with exit code ${actualExitCode}"
     }
 
     return New-Object PSObject -Property @{

--- a/tests/Python.Tests.ps1
+++ b/tests/Python.Tests.ps1
@@ -7,7 +7,8 @@ param (
     $ToolsDirectory
 )
 
-Import-Module "../helpers/pester-assertions.psm1"
+Import-Module (Join-Path $PSScriptRoot "../helpers/pester-assertions.psm1")
+Import-Module (Join-Path $PSScriptRoot "../helpers/common-helpers.psm1")
 
 Describe "Tests" {
 

--- a/tests/Python.Tests.ps1
+++ b/tests/Python.Tests.ps1
@@ -7,12 +7,12 @@ param (
     $ToolsDirectory
 )
 
-Import-Module "../helpers/common-helpers.psm1"
+Import-Module "../helpers/pester-assertions.psm1"
 
 Describe "Tests" {
 
     It "Python version" {
-        Get-CommandExitCode "python --version" | Should -Be 0
+        "python --version" | Should -ReturnZeroExitCode
         $pythonLocation = (Get-Command "python").Path
         $pythonLocation | Should -Not -BeNullOrEmpty
         $expectedPath = Join-Path -Path $ToolsDirectory -ChildPath "Python"
@@ -20,29 +20,29 @@ Describe "Tests" {
     }
 
     It "Run simple code" {
-        Get-CommandExitCode -Command "python ./simple_test.py" | Should -Be 0
+        "python ./simple_test.py" | Should -ReturnZeroExitCode
     }
 
     if (IsNixPlatform $Platform) {
         It "Check if all python modules are installed"  {
-            Get-CommandExitCode -Command "python ./python_modules.py" | Should -Be 0
+            "python ./python_modules.py" | Should -ReturnZeroExitCode
         }
 
         It "Check Tkinter module is available" {
-            Get-CommandExitCode -Command "python ./check_tkinter.py" | Should -Be 0
+            "python ./check_tkinter.py" | Should -ReturnZeroExitCode
         }
 
         It "Check if shared libraries are linked correctly" {
-            Get-CommandExitCode "bash ./psutil_install_test.sh" | Should -Be 0
+            "bash ./psutil_install_test.sh" | Should -ReturnZeroExitCode
         }
     }
 
     # Pyinstaller 3.5 does not support Python 3.8.0. Check issue https://github.com/pyinstaller/pyinstaller/issues/4311
     if ($Version -lt "3.8.0") {
         It "Validate Pyinstaller" {
-            Get-CommandExitCode "pip install pyinstaller" | Should -Be 0
-            Get-CommandExitCode -Command "pyinstaller --onefile ./simple_test.py" | Should -Be 0
-            Get-CommandExitCode "./dist/simple_test" | Should -Be 0
+            "pip install pyinstaller" | Should -ReturnZeroExitCode
+            "pyinstaller --onefile ./simple_test.py" | Should -ReturnZeroExitCode
+            "./dist/simple_test" | Should -ReturnZeroExitCode
         }
     }
 }


### PR DESCRIPTION
- Bring changes from PR: https://dev.azure.com/mseng/AzureDevOps/_git/HostedToolCache.Automation/pullrequest/542669?_a=files&path=%2Fpython%2Fscripts%2Fnix-prebuild.ps1
- Move `Execute-Command` to common helpers because it is cross-platform
- Add custom Pester assertion `ShouldReturnZeroExitCode` and enable verbose output