### PR TITLE
V malob/next refactoring

### DIFF
--- a/azure-pipelines/test-steps.yml
+++ b/azure-pipelines/test-steps.yml
@@ -1,7 +1,4 @@
 steps:
-- checkout: self
-  submodules: true
-
 - task: DownloadPipelineArtifact@2
   inputs:
     source: 'current'

--- a/azure-pipelines/test-steps.yml
+++ b/azure-pipelines/test-steps.yml
@@ -59,7 +59,6 @@ steps:
         Parameters=@{
           Version="$(VERSION)";
           Platform="$(Platform)";
-          ToolsDirectory="$(Agent.ToolsDirectory)";
         }
       }
       Invoke-Pester -Script $pesterParams -OutputFile "test_results.xml" -OutputFormat NUnitXml

--- a/azure-pipelines/test_job.yml
+++ b/azure-pipelines/test_job.yml
@@ -13,6 +13,9 @@ jobs:
         TestRunTitle: "Python $(VERSION) $(Platform) $(Architecture)"
 
   steps:
+  - checkout: self
+    submodules: true
+
   - task: PowerShell@2
     displayName: Fully cleanup the toolcache directory
     inputs:

--- a/azure-pipelines/test_job.yml
+++ b/azure-pipelines/test_job.yml
@@ -16,19 +16,8 @@ jobs:
   - task: PowerShell@2
     displayName: Fully cleanup the toolcache directory
     inputs:
-      TargetType: inline
-      script: |
-        if ($env:PLATFORM -match 'windows') {
-          $PythonFilter = "Name like '%Python%'"
-          Get-WmiObject Win32_Product -Filter $PythonFilter | Foreach-Object { 
-            Write-Host "Uninstalling $($_.Name) ..."
-            $_.Uninstall() | Out-Null 
-          }
-        }
-        $PythonToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Python"
-        Write-Host "Remove Python toolcache folder"
-        Remove-Item -Path $PythonToolcachePath -Recurse -Force
-      workingDirectory: '$(Build.BinariesDirectory)'
+      TargetType: filePath
+      filePath: tests/clean_toolcache.ps1
     condition: eq(variables['NeedCleanToolcacheDir'], true)
 
   - template: test-steps.yml

--- a/builders/Build-Python.ps1
+++ b/builders/Build-Python.ps1
@@ -15,7 +15,6 @@ $VerbosePreference = 'Continue'
 
 Import-Module (Join-Path $PSScriptRoot "../helpers" | Join-Path -ChildPath "common-helpers.psm1") -DisableNameChecking
 Import-Module (Join-Path $PSScriptRoot "../helpers" | Join-Path -ChildPath "nix-helpers.psm1") -DisableNameChecking
-Import-Module (Join-Path $PSScriptRoot "../helpers" | Join-Path -ChildPath "win-helpers.psm1") -DisableNameChecking
 
 <#
 Wrapper for class constructor to simplify importing PythonBuilder

--- a/builders/NixPythonBuilder.psm1
+++ b/builders/NixPythonBuilder.psm1
@@ -125,7 +125,7 @@ class NixPythonBuilder : PythonBuilder {
         $buildOutputLocation = $this.Make()
         Pop-Location
 
-        New-ToolStructureDump -ToolPath $this.ArtifactLocation -OutputFolder $this.ArtifactLocation
+        New-ToolStructureDump -ToolPath $this.GetFullPythonToolcacheLocation() -OutputFolder $this.ArtifactLocation
 
         Write-Host "Create sysconfig file..."
         $this.GetSysconfigDump()

--- a/builders/NixPythonBuilder.psm1
+++ b/builders/NixPythonBuilder.psm1
@@ -37,11 +37,10 @@ class NixPythonBuilder : PythonBuilder {
 
     [string] Download() {
         $sourceUri = $this.GetSourceUri()
-        $pythonSourceLocation = Join-Path -Path $this.ArtifactLocation -ChildPath "Python-$($this.Version).tgz"
-
         Write-Host "Sources URI: $sourceUri"
-        Download-Source -Uri $sourceUri -OutFile $pythonSourceLocation
-        Unpack-TarArchive -OutFile $pythonSourceLocation -ExpandArchivePath $this.TempFolderLocation
+
+        $archiveFilepath = Download-File -Uri $sourceUri -OutputFolder $this.ArtifactLocation
+        Unpack-TarArchive -ArchivePath $archiveFilepath -OutputDirectory $this.TempFolderLocation
         $expandedSourceLocation = Join-Path -Path $this.TempFolderLocation -ChildPath "Python-$($this.Version)"
         Write-Debug "Done; Sources location: $expandedSourceLocation"
 
@@ -50,7 +49,7 @@ class NixPythonBuilder : PythonBuilder {
 
     [void] ArchiveArtifact([string] $pythonToolLocation) {
         $artifact = Join-Path -Path $this.ArtifactLocation -ChildPath $this.OutputArtifactName
-        Archive-Zip -PathToArchive $pythonToolLocation -ToolZipFile $artifact 
+        Pack-Zip -PathToArchive $pythonToolLocation -ToolZipFile $artifact 
         Write-Debug "Done; Artifact location: $artifact"
     }
 
@@ -125,6 +124,8 @@ class NixPythonBuilder : PythonBuilder {
         Write-Host "Make for $($this.Platform)-$($this.PlatformVersion)..."
         $buildOutputLocation = $this.Make()
         Pop-Location
+
+        New-ToolStructureDump -ToolPath $this.ArtifactLocation -OutputFolder $this.ArtifactLocation
 
         Write-Host "Create sysconfig file..."
         $this.GetSysconfigDump()

--- a/builders/WinPythonBuilder.psm1
+++ b/builders/WinPythonBuilder.psm1
@@ -39,7 +39,7 @@ class WinPythonBuilder : PythonBuilder {
         $sourceUri = $this.GetSourceUri()
 
         Write-Host "Sources URI: $sourceUri"
-        $sourcesLocation = Download-File -Uri $sourceUri -BinPathFolder $this.ArtifactLocation
+        $sourcesLocation = Download-File -Uri $sourceUri -OutputFolder $this.ArtifactLocation
         Write-Debug "Done; Sources location: $sourcesLocation"
 
         return $sourcesLocation

--- a/helpers/common-helpers.psm1
+++ b/helpers/common-helpers.psm1
@@ -1,4 +1,4 @@
-Function Execute-Command {
+function Execute-Command {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
@@ -16,7 +16,7 @@ Function Execute-Command {
     }
 }
 
-Function Download-File {
+function Download-File {
     param(
         [Parameter(Mandatory=$true)]
         [Uri]$Uri,

--- a/helpers/common-helpers.psm1
+++ b/helpers/common-helpers.psm1
@@ -1,6 +1,7 @@
 Function Execute-Command {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory=$true)]
         [string] $Command
     )
 
@@ -15,10 +16,32 @@ Function Execute-Command {
     }
 }
 
+Function Download-File {
+    param(
+        [Parameter(Mandatory=$true)]
+        [Uri]$Uri,
+        [Parameter(Mandatory=$true)]
+        [String]$OutputFolder
+    )
+
+    $targetFilename = [IO.Path]::GetFileName($Uri)
+    $targetFilepath = Join-Path $OutputFolder $targetFilename
+
+    Write-Debug "Download source from $Uri to $OutFile"
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($Uri, $targetFilepath)
+        return $targetFilepath
+    } catch {
+        "$_"
+        break
+    }    
+}
 
 function New-ToolStructureDump {
     param(
+        [Parameter(Mandatory=$true)]
         [String]$ToolPath,
+        [Parameter(Mandatory=$true)]
         [String]$OutputFolder
     )
 
@@ -27,15 +50,14 @@ function New-ToolStructureDump {
     $folderContent = Get-ChildItem -Path $ToolPath -Recurse | Sort-Object | Select-Object -Property FullName, Length
     $folderContent | ForEach-Object {
         $relativePath = $_.FullName.Replace($ToolPath, "");
-        $fileSize = $_.Length
-        return "${relativePath} : ${fileSize} bytes"
+        return "${relativePath}"
     } | Out-File -FilePath $outputFile
 }
 
 function IsNixPlatform {
     param(
-        [String] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
-        $Platform
+        [Parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()]
+        [String]$Platform
     )
 
     return ($Platform -match "macos") -or ($Platform -match "ubuntu")

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -1,4 +1,4 @@
-Function Pack-Zip {
+function Pack-Zip {
     param(
         [Parameter(Mandatory=$true)]
         [String]$PathToArchive,
@@ -12,7 +12,7 @@ Function Pack-Zip {
     Pop-Location
 }
 
-Function Unpack-TarArchive {
+function Unpack-TarArchive {
     param(
         [Parameter(Mandatory=$true)]
         [String]$ArchivePath,

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -1,36 +1,26 @@
-Function Archive-Zip {
+Function Pack-Zip {
     param(
+        [Parameter(Mandatory=$true)]
         [String]$PathToArchive,
+        [Parameter(Mandatory=$true)]
         [String]$ToolZipFile
     )
 
+    Write-Debug "Pack $PathToArchive to $ToolZipFile"
     Push-Location -Path $PathToArchive
     zip -q -r $ToolZipFile * | Out-Null
     Pop-Location
 }
 
-Function Download-Source {
-    param(
-        [Uri]$Uri,
-        [String]$OutFile
-    )
-
-    Write-Debug "Download source from $Uri to $OutFile"
-    try {
-        (New-Object System.Net.WebClient).DownloadFile($Uri, $OutFile)
-    } catch {
-        "$_"
-        break
-    }    
-}
-
 Function Unpack-TarArchive {
     param(
-        [String]$OutFile,
-        [String]$ExpandArchivePath = $env:BUILD_STAGINGDIRECTORY,
-        [String]$TarCommands = "xzf"
+        [Parameter(Mandatory=$true)]
+        [String]$ArchivePath,
+        [Parameter(Mandatory=$true)]
+        [String]$OutputDirectory
     )
 
-    Write-Debug "Unpack $OutFile to $ExpandArchivePath"
-    tar -C $ExpandArchivePath -$TarCommands $OutFile
+    Write-Debug "Unpack $ArchivePath to $OutputDirectory"
+    tar -C $OutputDirectory -xzf $ArchivePath
+
 }

--- a/helpers/pester-assertions.psm1
+++ b/helpers/pester-assertions.psm1
@@ -5,9 +5,8 @@ function ShouldReturnZeroExitCode {
         [switch]$Negate
     )
 
-    $actualCommandOutput = Invoke-Expression -Command $ActualValue
+    Invoke-Expression -Command $ActualValue | ForEach-Object { Write-Host $_ }
     $actualExitCode = $LASTEXITCODE
-    Write-Host $actualCommandOutput
 
     [bool]$succeeded = $actualExitCode -eq 0
     if ($Negate) { $succeeded = -not $succeeded }

--- a/helpers/pester-extensions.psm1
+++ b/helpers/pester-extensions.psm1
@@ -5,6 +5,7 @@ function ShouldReturnZeroExitCode {
         [switch]$Negate
     )
 
+    Write-Host "Run command '${ActualValue}'"
     Invoke-Expression -Command $ActualValue | ForEach-Object { Write-Host $_ }
     $actualExitCode = $LASTEXITCODE
 

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -15,7 +15,7 @@ function Archive-SevenZip {
     }
 }
 
-Function Archive-Wim {
+function Archive-Wim {
     param(
         [String]$PathToArchive,
         [String]$ToolWimFile

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -1,30 +1,3 @@
-function Download-File {
-    Param (
-        [String]$Uri,
-        [String]$BinPathFolder
-    )
-
-    $BinPathFile = Join-Path $BinPathFolder $($Uri.Split('/')[-1])
-
-    Invoke-WebRequest -Uri $Uri -OutFile $BinPathFile
-    return $BinPathFile
-}
-
-function Install-App {
-    Param (
-        [String]$BinPathFile,
-        [String]$ArgumentInstall
-    )
-
-    try {
-        Start-Process -FilePath $BinPathFile -ArgumentList $ArgumentInstall -Wait
-    }
-    catch {
-        "$_"
-        break
-    }
-}
-
 function Archive-SevenZip {
     Param (
         [String]$Source,

--- a/tests/Python.Tests.ps1
+++ b/tests/Python.Tests.ps1
@@ -5,11 +5,10 @@ param (
     $Platform
 )
 
-Import-Module (Join-Path $PSScriptRoot "../helpers/pester-assertions.psm1")
+Import-Module (Join-Path $PSScriptRoot "../helpers/pester-extensions.psm1")
 Import-Module (Join-Path $PSScriptRoot "../helpers/common-helpers.psm1")
 
 Describe "Tests" {
-
     It "Python version" {
         "python --version" | Should -ReturnZeroExitCode
         $pythonLocation = (Get-Command "python").Path

--- a/tests/Python.Tests.ps1
+++ b/tests/Python.Tests.ps1
@@ -2,9 +2,7 @@ param (
     [Version] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
     $Version,
     [String] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $Platform,
-    [String] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
-    $ToolsDirectory
+    $Platform
 )
 
 Import-Module (Join-Path $PSScriptRoot "../helpers/pester-assertions.psm1")
@@ -16,7 +14,7 @@ Describe "Tests" {
         "python --version" | Should -ReturnZeroExitCode
         $pythonLocation = (Get-Command "python").Path
         $pythonLocation | Should -Not -BeNullOrEmpty
-        $expectedPath = Join-Path -Path $ToolsDirectory -ChildPath "Python"
+        $expectedPath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Python"
         $pythonLocation.startsWith($expectedPath) | Should -BeTrue
     }
 

--- a/tests/clean_toolcache.ps1
+++ b/tests/clean_toolcache.ps1
@@ -7,5 +7,5 @@ if ($env:PLATFORM -match 'windows') {
 }
 
 $PythonToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Python"
-Write-Host "Remove Python toolcache folder"
+Write-Host "Removing Python toolcache directory ..."
 Remove-Item -Path $PythonToolcachePath -Recurse -Force

--- a/tests/clean_toolcache.ps1
+++ b/tests/clean_toolcache.ps1
@@ -1,0 +1,11 @@
+if ($env:PLATFORM -match 'windows') {
+  $PythonFilter = "Name like '%Python%'"
+  Get-WmiObject Win32_Product -Filter $PythonFilter | Foreach-Object { 
+      Write-Host "Uninstalling $($_.Name) ..."
+      $_.Uninstall() | Out-Null 
+  }
+}
+
+$PythonToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Python"
+Write-Host "Remove Python toolcache folder"
+Remove-Item -Path $PythonToolcachePath -Recurse -Force


### PR DESCRIPTION
- Move toolcache clean up logic to the separate script: `tests/clean_toolcache.ps1`
- Remove Import `win-helpers.psm1` because it is not used anymore
- Rename `Archive-Zip` -> `Pack-Zip`
- `New-ToolStructureDump` 
- merge `Download-Source` and `Download-File` to `Download-File` function.
- change helpers argument naming